### PR TITLE
fix: anchor mispositioned in iframes when page is scrolled

### DIFF
--- a/.changeset/ripe-mails-juggle.md
+++ b/.changeset/ripe-mails-juggle.md
@@ -3,7 +3,3 @@
 ---
 
 When triggering autoscroll inside an iframe (e.g., HuggingFace Spaces, YouTube embedded videos), the anchor icon was displaced downward by the amount the parent page was scrolled, causing immediate upward scrolling instead of the expected behavior.
-
-**Root cause:** The coordinate transformation in `handleFrameMessage` added `window.scrollX/scrollY` to viewport-relative `clientX/clientY` coordinates from the iframe. Since the overlay uses `position: fixed` with `background-position` (already viewport-relative), the scroll offset caused a double-counting displacement.
-
-**Fix:** Removed the scroll offset addition, keeping only the iframe's viewport offset (`rect.left/rect.top`) to map iframe coordinates to the parent page's viewport.

--- a/.changeset/ripe-mails-juggle.md
+++ b/.changeset/ripe-mails-juggle.md
@@ -1,0 +1,9 @@
+---
+'@ubermanu/roller': patch
+---
+
+When triggering autoscroll inside an iframe (e.g., HuggingFace Spaces, YouTube embedded videos), the anchor icon was displaced downward by the amount the parent page was scrolled, causing immediate upward scrolling instead of the expected behavior.
+
+**Root cause:** The coordinate transformation in `handleFrameMessage` added `window.scrollX/scrollY` to viewport-relative `clientX/clientY` coordinates from the iframe. Since the overlay uses `position: fixed` with `background-position` (already viewport-relative), the scroll offset caused a double-counting displacement.
+
+**Fix:** Removed the scroll offset addition, keeping only the iframe's viewport offset (`rect.left/rect.top`) to map iframe coordinates to the parent page's viewport.

--- a/extensions/roller/src/Roller.ts
+++ b/extensions/roller/src/Roller.ts
@@ -270,8 +270,8 @@ export default class Roller {
     }
 
     const rect = iframe.getBoundingClientRect()
-    const x = (event.data.clientX ?? 0) + rect.left + (window.scrollX || 0)
-    const y = (event.data.clientY ?? 0) + rect.top + (window.scrollY || 0)
+    const x = (event.data.clientX ?? 0) + rect.left
+    const y = (event.data.clientY ?? 0) + rect.top
 
     if (event.data.action === 'start') {
       const elem = findScrollTop(this.htmlNode)


### PR DESCRIPTION
## Summary

When triggering autoscroll inside an iframe (e.g., HuggingFace Spaces, YouTube embedded videos), the anchor icon was displaced downward by the amount the parent page was scrolled, causing immediate upward scrolling instead of the expected behavior.

**Root cause:** The coordinate transformation in `handleFrameMessage` added `window.scrollX/scrollY` to viewport-relative `clientX/clientY` coordinates from the iframe. Since the overlay uses `position: fixed` with `background-position` (already viewport-relative), the scroll offset caused a double-counting displacement.

**Fix:** Removed the scroll offset addition, keeping only the iframe's viewport offset (`rect.left/rect.top`) to map iframe coordinates to the parent page's viewport.