### PR TITLE
fix: relay iframe scroll messages through nested iframe chains

### DIFF
--- a/.changeset/cute-animals-jump.md
+++ b/.changeset/cute-animals-jump.md
@@ -2,10 +2,4 @@
 '@ubermanu/roller': patch
 ---
 
-fix: relay iframe scroll messages through nested iframe chains
-
-When triggering autoscroll inside a deeply nested iframe (e.g., page → wrapper iframe → YouTube embed), the scroll message was consumed by the intermediate iframe instead of reaching the top frame, causing autoscroll to fail.
-
-**Root cause:** Two issues: (1) the `message` event listener in `init()` was only registered in the top frame (`if (!this.isInIframe)`), so intermediate iframes never listened for incoming messages. (2) `handleFrameMessage` always tried to scroll locally instead of relaying upward when the current frame was itself inside an iframe.
-
-**Fix:** Register the message listener in all frames, and relay messages to `window.parent` when the current frame is inside an iframe, enabling proper chaining through arbitrarily nested iframe hierarchies.
+Relay iframe scroll messages through nested iframe chains.

--- a/.changeset/cute-animals-jump.md
+++ b/.changeset/cute-animals-jump.md
@@ -1,0 +1,11 @@
+---
+'@ubermanu/roller': patch
+---
+
+fix: relay iframe scroll messages through nested iframe chains
+
+When triggering autoscroll inside a deeply nested iframe (e.g., page → wrapper iframe → YouTube embed), the scroll message was consumed by the intermediate iframe instead of reaching the top frame, causing autoscroll to fail.
+
+**Root cause:** Two issues: (1) the `message` event listener in `init()` was only registered in the top frame (`if (!this.isInIframe)`), so intermediate iframes never listened for incoming messages. (2) `handleFrameMessage` always tried to scroll locally instead of relaying upward when the current frame was itself inside an iframe.
+
+**Fix:** Register the message listener in all frames, and relay messages to `window.parent` when the current frame is inside an iframe, enabling proper chaining through arbitrarily nested iframe hierarchies.

--- a/extensions/roller/src/Roller.ts
+++ b/extensions/roller/src/Roller.ts
@@ -79,17 +79,13 @@ export default class Roller {
 
   init(): void {
     addEventListener('mousedown', this.handleMouseDown, true)
-    if (!this.isInIframe) {
-      addEventListener('message', this.handleFrameMessage)
-    }
+    addEventListener('message', this.handleFrameMessage)
   }
 
   destroy(): void {
     this.stop()
     removeEventListener('mousedown', this.handleMouseDown, true)
-    if (!this.isInIframe) {
-      removeEventListener('message', this.handleFrameMessage)
-    }
+    removeEventListener('message', this.handleFrameMessage)
   }
 
   startCycle(
@@ -274,52 +270,94 @@ export default class Roller {
     const y = (event.data.clientY ?? 0) + rect.top + (window.scrollY || 0)
 
     if (event.data.action === 'start') {
-      const elem = findScrollTop(this.htmlNode)
-      if (elem) {
+      if (this.isInIframe) {
+        window.parent.postMessage(
+          {
+            type: 'roller-scroll',
+            action: 'start',
+            clientX: x,
+            clientY: y,
+            frameId: event.data.frameId,
+          },
+          '*'
+        )
         this.iframeScrolling = true
-        this.start(elem, x, y)
         this.iframeOldX = x
         this.iframeOldY = y
+      } else {
+        const elem = findScrollTop(this.htmlNode)
+        if (elem) {
+          this.iframeScrolling = true
+          this.start(elem, x, y)
+          this.iframeOldX = x
+          this.iframeOldY = y
+        }
       }
     } else if (event.data.action === 'move' && this.iframeScrolling) {
-      const dx = x - this.iframeOldX!
-      const dy = y - this.iframeOldY!
-
-      if (utils.hypot(dx, dy) > this.options.moveThreshold) {
-        this.cursor = utils.getCursorStyleFromAngle(utils.angle(dx, dy))
-
-        let scrollDx = dx
-        let scrollDy = dy
-
-        if (this.options.sameSpeed) {
-          scrollDx = utils.max(scrollDx, 1) * 50
-          scrollDy = utils.max(scrollDy, 1) * 50
-        }
-
-        scrollDx = this.scale(scrollDx)
-        scrollDy = this.scale(scrollDy)
-
-        if (this.options.shouldCap) {
-          scrollDx = utils.max(scrollDx, this.options.capSpeed)
-          scrollDy = utils.max(scrollDy, this.options.capSpeed)
-        }
-
-        this.dirX = scrollDx
-        this.dirY = scrollDy
+      if (this.isInIframe) {
+        window.parent.postMessage(
+          {
+            type: 'roller-scroll',
+            action: 'move',
+            clientX: x,
+            clientY: y,
+            frameId: event.data.frameId,
+          },
+          '*'
+        )
+        this.iframeOldX = x
+        this.iframeOldY = y
       } else {
-        this.cursor = 'auto'
-        this.dirX = 0
-        this.dirY = 0
-      }
+        const dx = x - this.iframeOldX!
+        const dy = y - this.iframeOldY!
 
-      this.iframeOldX = x
-      this.iframeOldY = y
-      this.backgroundPositionX = x
-      this.backgroundPositionY = y
-      this.updateOverlay()
+        if (utils.hypot(dx, dy) > this.options.moveThreshold) {
+          this.cursor = utils.getCursorStyleFromAngle(utils.angle(dx, dy))
+
+          let scrollDx = dx
+          let scrollDy = dy
+
+          if (this.options.sameSpeed) {
+            scrollDx = utils.max(scrollDx, 1) * 50
+            scrollDy = utils.max(scrollDy, 1) * 50
+          }
+
+          scrollDx = this.scale(scrollDx)
+          scrollDy = this.scale(scrollDy)
+
+          if (this.options.shouldCap) {
+            scrollDx = utils.max(scrollDx, this.options.capSpeed)
+            scrollDy = utils.max(scrollDy, this.options.capSpeed)
+          }
+
+          this.dirX = scrollDx
+          this.dirY = scrollDy
+        } else {
+          this.cursor = 'auto'
+          this.dirX = 0
+          this.dirY = 0
+        }
+
+        this.iframeOldX = x
+        this.iframeOldY = y
+        this.backgroundPositionX = x
+        this.backgroundPositionY = y
+        this.updateOverlay()
+      }
     } else if (event.data.action === 'stop' && this.iframeScrolling) {
+      if (this.isInIframe) {
+        window.parent.postMessage(
+          {
+            type: 'roller-scroll',
+            action: 'stop',
+            frameId: event.data.frameId,
+          },
+          '*'
+        )
+      }
       this.iframeScrolling = false
-      this.stop()
+      this.iframeOldX = null
+      this.iframeOldY = null
     }
   }
 


### PR DESCRIPTION
## Summary
- Register the `message` event listener in all frames, not just the top frame
- Relay `roller-scroll` messages upward via `postMessage` when the current frame is itself inside an iframe

## Problem
When triggering autoscroll inside a deeply nested iframe (e.g., page -> wrapper iframe -> YouTube embed), the scroll message was consumed by the intermediate iframe instead of reaching the top frame. Two root causes:

1. The `message` event listener in `init()` was only registered in the top frame (`if (!this.isInIframe)`), so intermediate iframes never listened for incoming messages
2. `handleFrameMessage` always tried to scroll locally instead of relaying upward when the current frame was itself inside an iframe

## Fix
- Removed the `!this.isInIframe` guard so all frames register the message listener
- Added relay logic in `handleFrameMessage`: when `this.isInIframe` is true, forward the message to `window.parent` with adjusted coordinates instead of scrolling locally

This enables proper chaining through arbitrarily nested iframe hierarchies. Tested against https://developers.google.com/youtube/youtube_player_demo (3-level nesting) - now works correctly.
