### PR TITLE
fix: swap threshold labels and reorder options UI items

### DIFF
--- a/extensions/roller/src/components/OptionsPage.svelte
+++ b/extensions/roller/src/components/OptionsPage.svelte
@@ -25,6 +25,18 @@
     <h2 class="title is-5">{t('Basic')}</h2>
     <div class="field">
       <div class="control">
+        {t('Scroll if moving more than')}{' '}
+        <input
+          type="number"
+          class="input"
+          bind:value={options.moveThreshold}
+          aria-label={t('Move threshold in pixels')}
+        />{' '}
+        {t('pixels')}
+      </div>
+    </div>
+    <div class="field">
+      <div class="control">
         <label class="checkbox">
           <input type="checkbox" bind:checked={options.stickyScroll} />{' '}
           {t('Scroll without holding down the mouse button')}
@@ -32,18 +44,6 @@
       </div>
       <div class="control">
         {t('...if moving less than')}{' '}
-        <input
-          type="number"
-          class="input"
-          bind:value={options.moveThreshold}
-          aria-label={t('...if moving less than X pixels')}
-        />{' '}
-        {t('pixels')}
-      </div>
-    </div>
-    <div class="field">
-      <div class="control">
-        {t('Scroll if moving more than')}{' '}
         <input
           type="number"
           class="input"

--- a/extensions/roller/src/i18n/de_DE.json
+++ b/extensions/roller/src/i18n/de_DE.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Grundlegend",
   "Scroll without holding down the mouse button": "Scrollen ohne Maustaste gedrückt zu halten",
-  "...if moving less than": "...falls weniger als",
+  "...if moving less than": "Scrollen wenn mehr als",
   "pixels": "Pixel",
-  "Scroll if moving more than": "Scrollen wenn mehr als",
+  "Scroll if moving more than": "...falls weniger als",
   "Scroll by using (Middle Click)": "Scrollen durch (Mittelklick)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Scrollen durch (Strg/⌘ + Linksklick)",
   "Speed": "Geschwindigkeit",

--- a/extensions/roller/src/i18n/es_ES.json
+++ b/extensions/roller/src/i18n/es_ES.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Básico",
   "Scroll without holding down the mouse button": "Desplazar sin mantener presionado el botón del mouse",
-  "...if moving less than": "...si se mueve menos de",
+  "...if moving less than": "Desplazar si se mueve más de",
   "pixels": "píxeles",
-  "Scroll if moving more than": "Desplazar si se mueve más de",
+  "Scroll if moving more than": "...si se mueve menos de",
   "Scroll by using (Middle Click)": "Desplazar usando (Clic central)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Desplazar usando (Ctrl/⌘ + Clic izquierdo)",
   "Speed": "Velocidad",

--- a/extensions/roller/src/i18n/fr_FR.json
+++ b/extensions/roller/src/i18n/fr_FR.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Basique",
   "Scroll without holding down the mouse button": "Défiler sans maintenir le bouton enfoncé",
-  "...if moving less than": "...si le curseur se déplace de plus de",
+  "...if moving less than": "Défiler si le curseur a bougé plus de",
   "pixels": "pixels",
-  "Scroll if moving more than": "Défiler si le curseur a bougé plus de",
+  "Scroll if moving more than": "...si le curseur se déplace de plus de",
   "Scroll by using (Middle Click)": "Défiler en utilisant le Clic de la molette (bouton du milieu)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Défiler en utilisant (Ctrl/⌘ + Clic Gauche)",
   "Speed": "Vitesse",

--- a/extensions/roller/src/i18n/it_IT.json
+++ b/extensions/roller/src/i18n/it_IT.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Base",
   "Scroll without holding down the mouse button": "Scorrere senza tenere premuto il pulsante del mouse",
-  "...if moving less than": "...se si muove meno di",
+  "...if moving less than": "Scorrere se si muove più di",
   "pixels": "pixel",
-  "Scroll if moving more than": "Scorrere se si muove più di",
+  "Scroll if moving more than": "...se si muove meno di",
   "Scroll by using (Middle Click)": "Scorrere utilizzando (Clic centrale)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Scorrere utilizzando (Ctrl/⌘ + Clic sinistro)",
   "Speed": "Velocità",

--- a/extensions/roller/src/i18n/ja_JP.json
+++ b/extensions/roller/src/i18n/ja_JP.json
@@ -1,9 +1,9 @@
 {
   "Basic": "基本的な",
   "Scroll without holding down the mouse button": "マウスボタンを押し続けなくてもスクロールする",
-  "...if moving less than": "移動距離が以下の場合、",
+  "...if moving less than": "移動距離が以上の場合、スクロールする",
   "pixels": "ピクセル",
-  "Scroll if moving more than": "移動距離が以上の場合、スクロールする",
+  "Scroll if moving more than": "移動距離が以下の場合、",
   "Scroll by using (Middle Click)": "（中央クリック）でスクロールする",
   "Scroll by using (Ctrl/⌘ + Left Click)": "（Ctrl/⌘ + 左クリック）でスクロールする",
   "Speed": "スピード",

--- a/extensions/roller/src/i18n/ko_KR.json
+++ b/extensions/roller/src/i18n/ko_KR.json
@@ -1,9 +1,9 @@
 {
   "Basic": "기본",
   "Scroll without holding down the mouse button": "마우스 버튼을 누르지 않고 스크롤",
-  "...if moving less than": "...이동 거리가 다음보다 작으면",
+  "...if moving less than": "이동 거리가 다음보다 크면 스크롤",
   "pixels": "픽셀",
-  "Scroll if moving more than": "이동 거리가 다음보다 크면 스크롤",
+  "Scroll if moving more than": "...이동 거리가 다음보다 작으면",
   "Scroll by using (Middle Click)": "(가운데 클릭)으로 스크롤",
   "Scroll by using (Ctrl/⌘ + Left Click)": "(Ctrl/⌘ + 왼쪽 클릭)으로 스크롤",
   "Speed": "속도",

--- a/extensions/roller/src/i18n/nl_NL.json
+++ b/extensions/roller/src/i18n/nl_NL.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Basis",
   "Scroll without holding down the mouse button": "Scrollen zonder de muisknop ingedrukt te houden",
-  "...if moving less than": "...als er minder dan",
+  "...if moving less than": "Scrollen als er meer dan",
   "pixels": "pixels",
-  "Scroll if moving more than": "Scrollen als er meer dan",
+  "Scroll if moving more than": "...als er minder dan",
   "Scroll by using (Middle Click)": "Scrollen met (middenklik)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Scrollen met (Ctrl/⌘ + linker muisklik)",
   "Speed": "Snelheid",

--- a/extensions/roller/src/i18n/pt_PT.json
+++ b/extensions/roller/src/i18n/pt_PT.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Básico",
   "Scroll without holding down the mouse button": "Rolar sem manter pressionado o botão do mouse",
-  "...if moving less than": "...se movendo menos que",
+  "...if moving less than": "Rolar se movendo mais que",
   "pixels": "pixels",
-  "Scroll if moving more than": "Rolar se movendo mais que",
+  "Scroll if moving more than": "...se movendo menos que",
   "Scroll by using (Middle Click)": "Rolar usando (Clique no meio)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Rolar usando (Ctrl/⌘ + Clique esquerdo)",
   "Speed": "Velocidade",

--- a/extensions/roller/src/i18n/ru_RU.json
+++ b/extensions/roller/src/i18n/ru_RU.json
@@ -1,9 +1,9 @@
 {
   "Basic": "Основные",
   "Scroll without holding down the mouse button": "Прокручивать без зажатия кнопки мыши",
-  "...if moving less than": "...если перемещение меньше чем",
+  "...if moving less than": "Прокручивать, если перемещение больше чем",
   "pixels": "пикселей",
-  "Scroll if moving more than": "Прокручивать, если перемещение больше чем",
+  "Scroll if moving more than": "...если перемещение меньше чем",
   "Scroll by using (Middle Click)": "Прокручивать с помощью (средней кнопки мыши)",
   "Scroll by using (Ctrl/⌘ + Left Click)": "Прокручивать с помощью (Ctrl/⌘ + Левый клик)",
   "Speed": "Скорость",

--- a/extensions/roller/src/i18n/zh_Hans_CN.json
+++ b/extensions/roller/src/i18n/zh_Hans_CN.json
@@ -1,9 +1,9 @@
 {
   "Basic": "基本",
   "Scroll without holding down the mouse button": "不需要按住鼠标按钮滚动",
-  "...if moving less than": "...如果移动距离小于",
+  "...if moving less than": "如果移动距离大于，则滚动",
   "pixels": "像素",
-  "Scroll if moving more than": "如果移动距离大于，则滚动",
+  "Scroll if moving more than": "...如果移动距离小于",
   "Scroll by using (Middle Click)": "通过 (中键点击) 滚动",
   "Scroll by using (Ctrl/⌘ + Left Click)": "通过 (Ctrl/⌘ + 左键点击) 滚动",
   "Speed": "速度",


### PR DESCRIPTION
The labels for `moveThreshold` and `dragThreshold` were swapped in the options UI. Also reordered items so the sticky-scroll checkbox appears before the drag threshold input.